### PR TITLE
Support arbitrary state shapes using selectLocationState

### DIFF
--- a/__tests__/__snapshots__/connectRoutes.js.snap
+++ b/__tests__/__snapshots__/connectRoutes.js.snap
@@ -223,3 +223,26 @@ Object {
   "type": "@@redux-first-router/NOT_FOUND",
 }
 `;
+
+exports[`title and location options as selector functions 1`] = `
+Object {
+  "meta": Object {
+    "location": Object {
+      "current": Object {
+        "pathname": "/first",
+        "payload": Object {},
+        "type": "FIRST",
+      },
+      "history": undefined,
+      "kind": "push",
+      "prev": Object {
+        "pathname": "/first",
+        "payload": Object {},
+        "type": "FIRST",
+      },
+    },
+  },
+  "payload": Object {},
+  "type": "FIRST",
+}
+`;

--- a/__tests__/connectRoutes.js
+++ b/__tests__/connectRoutes.js
@@ -623,3 +623,23 @@ describe('reducer', () => {
 it('connectRoutes(undefined): throw error if no history provided', () => {
   expect(() => connectRoutes()).toThrowError()
 })
+
+it('title and location options as selector functions', () => {
+  const { middleware, reducer, enhancer } = setup('/first', {
+    title: state => state.title,
+    location: state => state.location
+  })
+  const middlewares = applyMiddleware(middleware)
+
+  const rootReducer = (state = {}, action = {}) => ({
+    location: reducer(state.location, action),
+    title: action.type
+  })
+
+  const store = createStore(rootReducer, middlewares, enhancer)
+  const action = store.dispatch({ type: 'FIRST' }) /*? $.meta */
+
+  store.getState() /*? $.location */
+
+  expect(action).toMatchSnapshot()
+})

--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -1,8 +1,8 @@
 // @flow
-import type { Middleware, StoreEnhancer } from 'redux'
+import type { StoreEnhancer } from 'redux'
 
 import pathToAction from './pure-utils/pathToAction'
-import nestAction, { nestHistory } from './pure-utils/nestAction'
+import { nestHistory } from './pure-utils/nestAction'
 import isLocationAction from './pure-utils/isLocationAction'
 import isServer from './pure-utils/isServer'
 import isReactNative from './pure-utils/isReactNative'
@@ -115,8 +115,10 @@ export default (
   }
 
   const {
-    selectLocationState = state => state.location,
-    selectTitleState = state => state.title,
+    location: locationKey = 'location',
+    title: titleKey = 'title',
+    selectLocationState = state => state[locationKey],
+    selectTitleState = state => state[titleKey],
     notFoundPath = '/not-found',
     scrollTop = false,
     onBeforeChange,
@@ -317,6 +319,9 @@ export default (
     }
 
     if (typeof window !== 'undefined') {
+      // `kind` is typed as ?string which will not throw if passed to .test.
+      // Typing kind as string threw other flow errrs in the codebase
+      // $FlowIssue
       if (typeof onBackNext === 'function' && /back|next|pop/.test(kind)) {
         onBackNext(dispatch, store.getState)
       }
@@ -544,4 +549,5 @@ export const scrollBehavior = () => _scrollBehavior
 
 export const updateScroll = () => _updateScroll && _updateScroll()
 
-export const selectLocationState = state => _selectLocationState(state)
+export const selectLocationState = (state: Object) =>
+  _selectLocationState(state)

--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -115,14 +115,10 @@ export default (
   }
 
   const {
-    // Flow doesn't like defaulting to string or func here, although it does not
-    // complain if we _do not_ provide a default value
-    // $FlowIssue
-    location: locationKey = 'location',
-    // $FlowIssue: Same as above
-    title: titleKey = 'title',
     notFoundPath = '/not-found',
     scrollTop = false,
+    location,
+    title,
     onBeforeChange,
     onAfterChange,
     onBackNext,
@@ -130,13 +126,27 @@ export default (
     initialDispatch: shouldPerformInitialDispatch = true
   }: Options = options
 
-  const selectLocationState = typeof locationKey === 'function'
-    ? locationKey
-    : state => state[locationKey]
+  let selectLocationState
+  if (typeof location === 'string') {
+    selectLocationState = state => state[location]
+  }
+  else if (typeof location === 'function') {
+    selectLocationState = location
+  }
+  else {
+    selectLocationState = state => state.location
+  }
 
-  const selectTitleState = typeof titleKey === 'function'
-    ? titleKey
-    : state => state[titleKey]
+  let selectTitleState
+  if (typeof title === 'string') {
+    selectTitleState = state => state[title]
+  }
+  else if (typeof title === 'function') {
+    selectTitleState = title
+  }
+  else {
+    selectTitleState = state => state.title
+  }
 
   const scrollBehavior = restoreScroll && restoreScroll(history)
 
@@ -328,10 +338,7 @@ export default (
       onAfterChange(dispatch, store.getState)
     }
 
-    if (typeof window !== 'undefined') {
-      // `kind` is typed as ?string which will not throw if passed to .test.
-      // Typing kind as string threw other flow errrs in the codebase
-      // $FlowIssue
+    if (typeof window !== 'undefined' && kind) {
       if (typeof onBackNext === 'function' && /back|next|pop/.test(kind)) {
         onBackNext(dispatch, store.getState)
       }

--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -115,8 +115,8 @@ export default (
   }
 
   const {
-    location: locationKey = 'location',
-    title: titleKey = 'title',
+    selectLocationState = state => state.location,
+    selectTitleState = state => state.title,
     notFoundPath = '/not-found',
     scrollTop = false,
     onBeforeChange,
@@ -145,7 +145,7 @@ export default (
   let prevLength = 1 // used by `historyCreateAction` to calculate if moving along history.entries track
 
   const reducer = createLocationReducer(INITIAL_LOCATION_STATE, routesMap)
-  const thunk = createThunk(routesMap, locationKey)
+  const thunk = createThunk(routesMap, selectLocationState)
   const initialDispatch = () => _initialDispatch && _initialDispatch()
 
   const windowDocument: Document = getDocument() // get plain object for window.document if server side
@@ -287,7 +287,7 @@ export default (
       if (skip) return true
     }
 
-    prevState = store.getState()[locationKey]
+    prevState = selectLocationState(store.getState())
     prevLocation = location.current
     prevLength = history.length
 
@@ -304,9 +304,9 @@ export default (
   const _afterRouteChange = (store: Store, next: Next, route: Route) => {
     const dispatch = middleware(store)(next) // re-create middleware's position in chain
     const state = store.getState()
-    const kind = state[locationKey].kind
-    const title = state[titleKey]
-    nextState = state[locationKey]
+    const kind = selectLocationState(state).kind
+    const title = selectTitleState(state)
+    nextState = selectLocationState(state)
 
     if (typeof route === 'object') {
       attemptCallRouteThunk(dispatch, store.getState, route)
@@ -377,14 +377,14 @@ export default (
     if (
       typeof window !== 'undefined' &&
       preloadedState &&
-      preloadedState[locationKey]
+      selectLocationState(preloadedState)
     ) {
-      preloadedState[locationKey].routesMap = routesMap
+      selectLocationState(preloadedState).routesMap = routesMap
     }
 
     const store = createStore(reducer, preloadedState, enhancer)
     const state = store.getState()
-    const location = state && state[locationKey]
+    const location = state && selectLocationState(state)
 
     if (!location || !location.pathname) {
       throw new Error(
@@ -455,7 +455,7 @@ export default (
 
   _history = history
   _scrollBehavior = scrollBehavior
-  _locationKey = locationKey
+  _selectLocationState = selectLocationState
   let _initialDispatch
 
   _updateScroll = (performedByUser: boolean = true) => {
@@ -509,7 +509,7 @@ export default (
 let _history
 let _scrollBehavior
 let _updateScroll
-let _locationKey
+let _selectLocationState
 
 export const push = (pathname: string) => _history.push(pathname)
 
@@ -544,4 +544,4 @@ export const scrollBehavior = () => _scrollBehavior
 
 export const updateScroll = () => _updateScroll && _updateScroll()
 
-export const locationKey = () => _locationKey
+export const selectLocationState = state => _selectLocationState(state)

--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -115,10 +115,12 @@ export default (
   }
 
   const {
+    // Flow doesn't like defaulting to string or func here, although it does not
+    // complain if we _do not_ provide a default value
+    // $FlowIssue
     location: locationKey = 'location',
+    // $FlowIssue: Same as above
     title: titleKey = 'title',
-    selectLocationState = state => state[locationKey],
-    selectTitleState = state => state[titleKey],
     notFoundPath = '/not-found',
     scrollTop = false,
     onBeforeChange,
@@ -127,6 +129,14 @@ export default (
     restoreScroll,
     initialDispatch: shouldPerformInitialDispatch = true
   }: Options = options
+
+  const selectLocationState = typeof locationKey === 'function'
+    ? locationKey
+    : state => state[locationKey]
+
+  const selectTitleState = typeof titleKey === 'function'
+    ? titleKey
+    : state => state[titleKey]
 
   const scrollBehavior = restoreScroll && restoreScroll(history)
 

--- a/src/flow-types.js
+++ b/src/flow-types.js
@@ -43,6 +43,8 @@ export type RouteNames = Array<string>
 export type Options = {
   title?: string,
   location?: string,
+  selectLocationState?: (state: Object) => LocationState,
+  selectTitleState?: (state: Object) => string,
   notFoundPath?: string,
   scrollTop?: boolean,
   onBeforeChange?: (

--- a/src/flow-types.js
+++ b/src/flow-types.js
@@ -40,11 +40,12 @@ export type Navigators = {
 export type Routes = Array<Route>
 export type RouteNames = Array<string>
 
+export type SelectLocationState = (state: Object) => LocationState
+export type SelectTitleState = (state: Object) => string
+
 export type Options = {
-  title?: string,
-  location?: string,
-  selectLocationState?: (state: Object) => LocationState,
-  selectTitleState?: (state: Object) => string,
+  title?: string | SelectTitleState,
+  location?: string | SelectLocationState,
   notFoundPath?: string,
   scrollTop?: boolean,
   onBeforeChange?: (

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export {
   history,
   scrollBehavior,
   updateScroll,
-  locationKey
+  selectLocationState
 } from './connectRoutes'
 
 export const NOT_FOUND = '@@redux-first-router/NOT_FOUND'

--- a/src/pure-utils/createThunk.js
+++ b/src/pure-utils/createThunk.js
@@ -2,11 +2,11 @@
 import type { Store } from 'redux'
 import type { RoutesMap } from '../flow-types'
 
-export default (routesMap: RoutesMap, locationKey: string) => ({
+export default (routesMap: RoutesMap, selectLocationState: Function) => ({
   dispatch,
   getState
 }: Store<*, *>): Promise<any> => {
-  const { type } = getState()[locationKey]
+  const { type } = selectLocationState(getState())
   const route = routesMap[type]
 
   if (route && typeof route.thunk === 'function') {

--- a/src/pure-utils/createThunk.js
+++ b/src/pure-utils/createThunk.js
@@ -1,11 +1,11 @@
 // @flow
 import type { Store } from 'redux'
-import type { RoutesMap } from '../flow-types'
+import type { RoutesMap, SelectLocationState } from '../flow-types'
 
-export default (routesMap: RoutesMap, selectLocationState: Function) => ({
-  dispatch,
-  getState
-}: Store<*, *>): Promise<any> => {
+export default (
+  routesMap: RoutesMap,
+  selectLocationState: SelectLocationState
+) => ({ dispatch, getState }: Store<*, *>): Promise<*> => {
   const { type } = selectLocationState(getState())
   const route = routesMap[type]
 


### PR DESCRIPTION
This PR is meant to continue the discussion of how to best handle a use case like Immutable.js, where the state shape of the app differs from what this lib expects. If you like what I've done here then by all means let's get it merged, but I'm also open to any and all feedback. Ultimately I really just want to be able to use this for my own projects which happen to use Immutable, but this change would also help anyone else dealing with a different state shape.

## What is this

This came out of the discussion in #20, but basically it would help widespread adoption of this lib if it was not dependent on using plain objects for your state shape.

## What changed

* **New options:** `selectLocationState` and `selectTitleState`. These are both functions that replace the use case of `location` and `title` options.

Previously the `location` option (referened as `locationKey` internally) allowed the user to specify _where_ in state the location reducer state would be held. However, this assumed that the user would be using plain javascipt objects as their state shape. By replacing this string option with a selector function we allow much more flexibility over how the location state is stored and accessed.

Before:

```js
const { reducer, middleware, enhancer } = connectRoutes(history, routesMap, {
  location: 'customLocationKey',
});
```
After:

```js
const { reducer, middleware, enhancer } = connectRoutes(history, routesMap, {
  selectLocationState: state => state.customLocationKey,
});
```

Or with another library like Immutable.js. In this example `state` is an `Immutable.Map`:

```js
const { reducer, middleware, enhancer } = connectRoutes(history, routesMap, {
  selectLocationState: state => state.get('customLocationKey'),
});
```

## Breaking Changes ⚠

Since `selectLocationState` makes the location option unecessary it has been removed. But since it was publicly exported as part of the API this represents a breaking change. In fact this did break `redux-first-router-link` during development because it depends on the `locationKey`. This is simple enough to solve by exporting the `selectLocationState` function instead of the string key, so there shouldn't be any long term issues here and I will PR the other repo too if you want to move forward with this change. But a breaking change like this would warrant a major version bump. Just something to be aware of.