### PR TITLE
Prevent actionToPath from returning an empty pathname

### DIFF
--- a/__tests__/pure-utils.js
+++ b/__tests__/pure-utils.js
@@ -243,6 +243,13 @@ describe('actionToPath(action, routesMap)', () => {
     performMatch = () => actionToPath({ type: 'INFO' }, routesMap)
     expect(performMatch).not.toThrowError()
   })
+
+  it('never returns an empty string when path has single optional param that is undefined', () => {
+    const action = { type: 'INFO_PARAM', payload: { param: undefined } }
+    const routesMap = { INFO_PARAM: '/:param?' }
+    const path = actionToPath(action, routesMap) /*? */
+    expect(path).toEqual('/')
+  })
 })
 
 describe('changePageTitle()', () => {

--- a/src/pure-utils/actionToPath.js
+++ b/src/pure-utils/actionToPath.js
@@ -20,7 +20,7 @@ export default (
     ? _payloadToParams(route, action.payload)
     : action.payload
 
-  const path = pathToRegexp.compile(routePath)(params || {})
+  const path = pathToRegexp.compile(routePath)(params || {}) || '/'
 
   const query =
     action.query ||


### PR DESCRIPTION
An empty pathname can be returned when the route map contains a path
with a single optional parameter such as {FOO: '/:foo?'} and an action
is supplied with the optional parameter undefined in the payload
such as {type: 'FOO', payload: {foo: undefined}}.

Previously, the pathname returned would be an empty string however the
History package treats empty paths as '/' so history.listen() handler
immediately dispatches a new action to change the location to '/'. 

This commit ensures that any empty pathname is converted to '/' before
being returned which prevents the double dispatch further on.