### PR TITLE
Support passing an additional arg to all thunks

### DIFF
--- a/__tests__/__snapshots__/connectRoutes.js.snap
+++ b/__tests__/__snapshots__/connectRoutes.js.snap
@@ -3,7 +3,7 @@
 exports[`QUERY: currentPathName changes, but pathname stays the same (only query changes) 1`] = `
 Object {
   "location": Object {
-    "hasSSR": undefined,
+    "hasSSR": true,
     "history": undefined,
     "kind": "push",
     "pathname": "/first",
@@ -37,7 +37,7 @@ Object {
 exports[`QUERY: dispatched as action.meta.query 1`] = `
 Object {
   "location": Object {
-    "hasSSR": undefined,
+    "hasSSR": true,
     "history": undefined,
     "kind": "push",
     "pathname": "/third",
@@ -71,7 +71,7 @@ Object {
 exports[`QUERY: dispatched as action.payload.query 1`] = `
 Object {
   "location": Object {
-    "hasSSR": undefined,
+    "hasSSR": true,
     "history": undefined,
     "kind": "back",
     "pathname": "/third",
@@ -95,7 +95,7 @@ Object {
 exports[`QUERY: dispatched as action.query 1`] = `
 Object {
   "location": Object {
-    "hasSSR": undefined,
+    "hasSSR": true,
     "history": undefined,
     "kind": "push",
     "pathname": "/third",
@@ -129,7 +129,7 @@ Object {
 exports[`QUERY: generated from pathToAction within <Link /> 1`] = `
 Object {
   "location": Object {
-    "hasSSR": undefined,
+    "hasSSR": true,
     "history": undefined,
     "kind": "push",
     "pathname": "/first",
@@ -163,7 +163,7 @@ Object {
 exports[`QUERY: history.push("/path?search=foo") 1`] = `
 Object {
   "location": Object {
-    "hasSSR": undefined,
+    "hasSSR": true,
     "history": undefined,
     "kind": "push",
     "pathname": "/third",

--- a/docs/connectRoutes.md
+++ b/docs/connectRoutes.md
@@ -134,8 +134,9 @@ type Options = {
   restoreScroll?: ((PrevLocationState, LocationState) => boolean | string | array) => ScrollBehavior,
   onBeforeChange?: (Dispatch, GetState) => void,
   onAfterChange?: (Dispatch, GetState) => void,
-  initialDispatch?: boolean, // default: true
-  onBackNext?: (Dispatch, GetState, HistoryLocation, Action) => void
+  initialDispatch?: boolean, // default: true,
+  onBackNext?: (Dispatch, GetState, HistoryLocation, Action) => void,
+  extraThunkArgument: any
 }
 ```
 
@@ -151,17 +152,18 @@ restoration, and should be fine while developing, especially if you're using Chr
 * **restoreScroll** - the `restoreScroll` is a call to `redux-first-router-restore-scroll`'s restoreScroll` function, with a `shouldUpdateScroll` callback passed a single argument. See the [scroll restoration doc](./scroll-restoration.md) for more info.
 
 * **onAfterChange** - `onAfterChange` is a simple function that will be called after the routes change. It's passed your standard `dispatch` and `getState` arguments
-like a thunk.
+like a thunk. If the `extraThunkArgument` option was supplied then its value will be passed as the final argument.
 
-* **onBeforeChange** - `onBeforeChange` is a simple function that will be called before the routes change. It's passed your standard `dispatch` and `getState` arguments like a thunk, as well as the `action` as a third parameter. Keep in mind unlike `onAfterChange`, the action has not been dispatched yet. Therefore,
+* **onBeforeChange** - `onBeforeChange` is a simple function that will be called before the routes change. It's passed your standard `dispatch` and `getState` arguments like a thunk, as well as the `action` as a third parameter. If the `extraThunkArgument` option was supplied then it's value will be passed as a fourth parameter. Keep in mind unlike `onAfterChange`, the action has not been dispatched yet. Therefore,
 the state won't reflect it. So you need to use the action to extract URL params from the `payload`. You can use this function to efficiently short-circuit the middleware by calling `dispatch(redirect(newAction))`, where `newAction` has the matching `type` and `payload` of the route you would like to redirect to. Using `onBeforeChange` and `location.kind === 'redirect'` + `res.redirect(301, pathname)` in your `serverRender` function is the idiom here for handling redirects server-side. See [server-rendering docs](.server-rendering.md) for more info.
 
-* **onBackNext** - `onBackNext` is a simple function that will be called whenever the user uses the browser *back/next* buttons. It's passed your standard `dispatch` and `getState` arguments like a thunk. Actions with kinds `back`, `next`, and `pop` trigger this.
+* **onBackNext** - `onBackNext` is a simple function that will be called whenever the user uses the browser *back/next* buttons. It's passed your standard `dispatch` and `getState` arguments like a thunk. If the `extraThunkArgument` option was supplied then its value will be passed as the final argument. Actions with kinds `back`, `next`, and `pop` trigger this.
 
 * **initialDispatch** - `initialDispatch` can be set to `false` to bypass the initial dispatch, so you can do it manually, perhaps after running sagas. An `initialDispatch` function will exist in the object returned by `connectRoutes`. Simply call `initialDispatch()` when you are ready.
 
-* **navigators** - `navigators` is a map of of your Redux state keys to *React Navigation* navigators. Here's how you do it:
+* **extraThunkArgument** - `extraThunkArgument` can be any value you'd like to be passed to your thunks. This allows you to inject arbitrary parameters into your route thunks just like [redux-thunk](https://github.com/gaearon/redux-thunk#injecting-a-custom-argument). This value will also be passed to `onAfterChange`, `onBeforeChange` and `onBackNext` since they function like thunks. Note however, that `onBeforeChange` passes the `action` as the third argument. Therefore the value of `extraThunkArgument` will be passed as the _fourth_ argument to `onBeforeChange`.
 
+* **navigators** - `navigators` is a map of of your Redux state keys to *React Navigation* navigators. Here's how you do it:
 
 ```js
 import reduxNavigation from 'redux-first-router-navigation'
@@ -174,3 +176,4 @@ const options = {
 ```
 
 > See the [Redux Navigation](./redux-navigation) docs for info on how to use *React Navigation* with this package. We think you're gonna love it :)
+

--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -324,7 +324,10 @@ export default (
     nextState = selectLocationState(state)
 
     if (typeof route === 'object') {
-      attemptCallRouteThunk(dispatch, store.getState, route, extraThunkArgument)
+      attemptCallRouteThunk(dispatch, store.getState, route, {
+        selectLocationState,
+        extraThunkArgument
+      })
     }
 
     if (onAfterChange) {

--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -128,7 +128,8 @@ export default (
     onBackNext,
     restoreScroll,
     initialDispatch: shouldPerformInitialDispatch = true,
-    querySerializer
+    querySerializer,
+    extraThunkArgument
   }: Options = options
 
   const selectLocationState = typeof location === 'function'
@@ -159,7 +160,7 @@ export default (
   let prevLength = 1 // used by `historyCreateAction` to calculate if moving along history.entries track
 
   const reducer = createLocationReducer(INITIAL_LOCATION_STATE, routesMap)
-  const thunk = createThunk(routesMap, selectLocationState)
+  const thunk = createThunk(routesMap, selectLocationState, extraThunkArgument)
   const initialDispatch = () => _initialDispatch && _initialDispatch()
 
   const windowDocument: Document = getDocument() // get plain object for window.document if server side
@@ -323,9 +324,11 @@ export default (
     nextState = selectLocationState(state)
 
     if (typeof route === 'object') {
-      attemptCallRouteThunk(dispatch, store.getState, route)
+      attemptCallRouteThunk(dispatch, store.getState, route, extraThunkArgument)
     }
 
+    // TODO: Should these other thunk-like functions also be passed the
+    // extraThunkArgument?
     if (onAfterChange) {
       onAfterChange(dispatch, store.getState)
     }

--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -298,7 +298,7 @@ export default (
         store.dispatch(action)
       }
 
-      onBeforeChange(dispatch, store.getState, action)
+      onBeforeChange(dispatch, store.getState, action, extraThunkArgument)
       if (skip) return true
     }
 
@@ -327,15 +327,13 @@ export default (
       attemptCallRouteThunk(dispatch, store.getState, route, extraThunkArgument)
     }
 
-    // TODO: Should these other thunk-like functions also be passed the
-    // extraThunkArgument?
     if (onAfterChange) {
-      onAfterChange(dispatch, store.getState)
+      onAfterChange(dispatch, store.getState, extraThunkArgument)
     }
 
     if (typeof window !== 'undefined' && kind) {
       if (typeof onBackNext === 'function' && /back|next|pop/.test(kind)) {
-        onBackNext(dispatch, store.getState)
+        onBackNext(dispatch, store.getState, extraThunkArgument)
       }
 
       setTimeout(() => {

--- a/src/flow-types.js
+++ b/src/flow-types.js
@@ -10,7 +10,11 @@ export type RouteObject = {
   capitalizedWords?: boolean,
   toPath?: (param: string, key?: string) => string,
   fromPath?: (path: string, key?: string) => string,
-  thunk?: (dispatch: Dispatch, getState: GetState) => any | Promise<any>,
+  thunk?: (
+    dispatch: Dispatch,
+    getState: GetState,
+    extraThunkArgument?: any
+  ) => any | Promise<any>,
   navKey?: string
 }
 
@@ -56,10 +60,19 @@ export type Options = {
   onBeforeChange?: (
     dispatch: Dispatch,
     getState: GetState,
-    action: Action
+    action: Action,
+    extraThunkArgument?: any
   ) => void,
-  onAfterChange?: (dispatch: Dispatch, getState: GetState) => void,
-  onBackNext?: (dispatch: Dispatch, getState: GetState) => void,
+  onAfterChange?: (
+    dispatch: Dispatch,
+    getState: GetState,
+    extraThunkArgument?: any
+  ) => void,
+  onBackNext?: (
+    dispatch: Dispatch,
+    getState: GetState,
+    extraThunkArgument?: any
+  ) => void,
   restoreScroll?: History => ScrollBehavior,
   initialDispatch?: boolean,
   querySerializer?: QuerySerializer,

--- a/src/flow-types.js
+++ b/src/flow-types.js
@@ -81,7 +81,8 @@ export type Options = {
       action: Object,
       navigationAction: ?NavigationAction
     }
-  }
+  },
+  extraThunkArgument?: any
 }
 
 export type ScrollBehavior = Object

--- a/src/pure-utils/attemptCallRouteThunk.js
+++ b/src/pure-utils/attemptCallRouteThunk.js
@@ -7,17 +7,22 @@ import type {
   LocationState
 } from '../flow-types'
 
+type Options = {
+  selectLocationState: (state: Object) => LocationState,
+  extraThunkArgument?: any
+}
+
 export default (
   dispatch: Dispatch,
   getState: GetState,
   route: RouteObject,
-  extraThunkArgument: any
+  { selectLocationState, extraThunkArgument }: Options
 ) => {
   if (typeof window !== 'undefined') {
     const thunk = route.thunk
 
     if (typeof thunk === 'function') {
-      const { kind, hasSSR }: LocationState = getState().location // TODO: This should be using selectLocationState
+      const { kind, hasSSR }: LocationState = selectLocationState(getState())
 
       // call thunks always if it's not initial load of the app or only if it's load
       // without SSR setup yet, so app state is setup on client when prototyping,

--- a/src/pure-utils/attemptCallRouteThunk.js
+++ b/src/pure-utils/attemptCallRouteThunk.js
@@ -7,18 +7,23 @@ import type {
   LocationState
 } from '../flow-types'
 
-export default (dispatch: Dispatch, getState: GetState, route: RouteObject) => {
+export default (
+  dispatch: Dispatch,
+  getState: GetState,
+  route: RouteObject,
+  extraThunkArgument: any
+) => {
   if (typeof window !== 'undefined') {
     const thunk = route.thunk
 
     if (typeof thunk === 'function') {
-      const { kind, hasSSR }: LocationState = getState().location
+      const { kind, hasSSR }: LocationState = getState().location // TODO: This should be using selectLocationState
 
       // call thunks always if it's not initial load of the app or only if it's load
       // without SSR setup yet, so app state is setup on client when prototyping,
       // such as with with webpack-dev-server before server infrastructure is built
       if (kind !== 'load' || (kind === 'load' && !hasSSR)) {
-        const prom = thunk(dispatch, getState)
+        const prom = thunk(dispatch, getState, extraThunkArgument)
 
         if (prom && typeof prom.next === 'function') {
           prom.next(updateScroll)

--- a/src/pure-utils/createThunk.js
+++ b/src/pure-utils/createThunk.js
@@ -4,13 +4,14 @@ import type { RoutesMap, SelectLocationState } from '../flow-types'
 
 export default (
   routesMap: RoutesMap,
-  selectLocationState: SelectLocationState
+  selectLocationState: SelectLocationState,
+  extraThunkArgument: any
 ) => ({ dispatch, getState }: Store<*, *>): Promise<*> => {
   const { type } = selectLocationState(getState())
   const route = routesMap[type]
 
   if (route && typeof route.thunk === 'function') {
-    return Promise.resolve(route.thunk(dispatch, getState))
+    return Promise.resolve(route.thunk(dispatch, getState, extraThunkArgument))
   }
 
   return Promise.resolve()


### PR DESCRIPTION
This PR does exactly what I outlined in this issue: https://github.com/faceyspacey/redux-first-router/issues/54

Some addition things to note:

* Snapshots were updated. I'm not sure why though, because the snapshots differed as soon as I ran the tests, even before I made any changes.
* I took the opportunity to fix a potentially undiscovered bug where thunks depended on a certain global state shap (see c0cb9e7).