### PR TITLE
fix($pathToAction): recognize blank string parameters as NaN

### DIFF
--- a/__tests__/pure-utils.js
+++ b/__tests__/pure-utils.js
@@ -154,6 +154,16 @@ describe('pathToAction(path, routesMap)', () => {
     expect(action.payload.param).toEqual(69)
   })
 
+  it('does not parse a blank string "" as NaN', () => {
+    const path = '/info'
+    const routesMap = {
+      INFO_WILDCARD: { path: '/info(.*)' }
+    }
+
+    const action = pathToAction(path, routesMap)
+    expect(action.payload[0]).toEqual('')
+  })
+
   it('parsed path not found and return NOT_FOUND action.type: "@@redux-first-router/NOT_FOUND"', () => {
     const path = '/info/foo/bar'
     const routesMap = {

--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -43,7 +43,9 @@ export default (
     const payload = keys.reduce((payload, key, index) => {
       let value = match && match[index + 1] // item at index 0 is the overall match, whereas those after correspond to the key's index
 
-      value = !isNaN(value)
+      value = typeof value === 'string' &&
+        !value.match(/^\s*$/) &&
+        !isNaN(value) // check that value is not a blank string, and is numeric
         ? parseFloat(value) // make sure pure numbers aren't passed to reducers as strings
         : value
 


### PR DESCRIPTION
In certain route configurations (ex., `/my/path(.*)`), a route parameter may be a blank string. The existing code uses `isNaN()` to check if the parameter is numeric, and then parse it as a float. However, `isNaN('')` is `false`, but `parseFloat('')` is `NaN`, meaning that blank parameters would be converted to `NaN`.  (See [MDN's writeup on confusing behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#Confusing_special-case_behavior).)

This manifested itself in the browser - for paths like `/my/path(.*)`, visiting `/my/path` would change the URL shown in the browser to `/my/pathNaN`.