### PR TITLE
docs($docs): update docs to be clear about importance of enhancer order

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ const { reducer, middleware, enhancer } = connectRoutes(history, routesMap) // y
 // and you already know how the story ends:
 const rootReducer = combineReducers({ location: reducer, userId: userIdReducer })
 const middlewares = applyMiddleware(middleware)
+// note the order: enhancer, then middlewares
 const store = createStore(rootReducer, compose(enhancer, middlewares))
 ```
 

--- a/docs/connectRoutes.md
+++ b/docs/connectRoutes.md
@@ -174,3 +174,23 @@ const options = {
 ```
 
 > See the [Redux Navigation](./redux-navigation) docs for info on how to use *React Navigation* with this package. We think you're gonna love it :)
+
+## Returned Values
+
+`connectRoutes` returns an `enhancer` and a `middleware` that you will need to use in order to tie everything together.  It should be noted that the order that those values are applied to the store *does matter*.  The enhancer must come first in order for the middleware to correctly function.
+
+The returned `reducer` expects its key in the root reducer to be at `location`, unless specified otherwise via the `location` option (outlined above).
+
+```
+import * as reducers from '../reducers/';
+import * as otherMiddlewares from '../middlewares';
+import { connectRoutes } from 'redux-first-router'
+import { combineReducers, createStore, applyMiddleware, compose } from 'redux'
+
+const { reducer, middleware, enhancer } = connectRoutes(history, routesMap)
+
+const rootReducer = combineReducers({ ...reducers, location: reducer })
+const middlewares = applyMiddleware([ middleware, ...otherMiddlewares ])
+// note that the enhancer comes before other middleware
+const store = createStore(rootReducer, compose(enhancer, middlewares))
+```

--- a/docs/connectRoutes.md
+++ b/docs/connectRoutes.md
@@ -181,7 +181,7 @@ const options = {
 
 The returned `reducer` expects its key in the root reducer to be at `location`, unless specified otherwise via the `location` option (outlined above).
 
-```
+```js
 import * as reducers from '../reducers/';
 import * as otherMiddlewares from '../middlewares';
 import { connectRoutes } from 'redux-first-router'

--- a/docs/server-rendering.md
+++ b/docs/server-rendering.md
@@ -29,6 +29,7 @@ export async function configureStore(req) {
 
   const { reducer, middleware, enhancer, thunk } = connectRoutes(history, routesMap) // notice `thunk`
   const rootReducer = combineReducers({ location: reducer })
+  // note the order that the enhancer and middleware are composed in: enhancer first, then middleware
   const store = createStore(rootReducer, compose(enhancer, applyMiddleware(middleware)))
 
   // using redux-thunk perhaps request and dispatch some app-wide state as well, e.g:
@@ -108,6 +109,7 @@ export default async function configureStore(req, res) {
 
   const { reducer, middleware, enhancer, thunk } = connectRoutes(history, routesMap) 
   const rootReducer = combineReducers({ location: reducer })
+  // enhancer first, then middleware
   const store = createStore(rootReducer, compose(enhancer, applyMiddleware(middleware)))
 
   // the idiomatic way to handle redirects


### PR DESCRIPTION
This adds some comments to example code snippets where the enhancer and middleware appear in order to clarify the importance of ordering them correctly within the `compose` block.  Also adds a small section to the `connectRoutes` doc about the return values.

This should hopefully avoid confusion for others in the future. 

(per: https://github.com/faceyspacey/redux-first-router/issues/60) 

