### PR TITLE
fix: fix location access bug in attemptCallRouteThunk

### DIFF
--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -323,7 +323,12 @@ export default (
     nextState = selectLocationState(state)
 
     if (typeof route === 'object') {
-      attemptCallRouteThunk(dispatch, store.getState, route)
+      attemptCallRouteThunk(
+        dispatch,
+        store.getState,
+        route,
+        selectLocationState
+      )
     }
 
     if (onAfterChange) {

--- a/src/pure-utils/attemptCallRouteThunk.js
+++ b/src/pure-utils/attemptCallRouteThunk.js
@@ -4,15 +4,21 @@ import type {
   Dispatch,
   GetState,
   RouteObject,
-  LocationState
+  LocationState,
+  SelectLocationState
 } from '../flow-types'
 
-export default (dispatch: Dispatch, getState: GetState, route: RouteObject) => {
+export default (
+  dispatch: Dispatch,
+  getState: GetState,
+  route: RouteObject,
+  selectLocationState: SelectLocationState
+) => {
   if (typeof window !== 'undefined') {
     const thunk = route.thunk
 
     if (typeof thunk === 'function') {
-      const { kind, hasSSR }: LocationState = getState().location
+      const { kind, hasSSR }: LocationState = selectLocationState(getState())
 
       // call thunks always if it's not initial load of the app or only if it's load
       // without SSR setup yet, so app state is setup on client when prototyping,


### PR DESCRIPTION
`attemptCallRouteThunk` accessed the location state via `getState().location` which doesn't work with
custom locations in the state, instead `selectLocationState` must be passed to it and used