### PR TITLE
Fixes for SEO with basename

### DIFF
--- a/__tests__/__snapshots__/pure-utils.js.snap
+++ b/__tests__/__snapshots__/pure-utils.js.snap
@@ -35,7 +35,7 @@ Object {
   "entries": Array [
     Object {
       "hash": "",
-      "key": undefined,
+      "key": "345678",
       "pathname": "/",
       "search": "",
       "state": undefined,

--- a/__tests__/action-creators.js
+++ b/__tests__/action-creators.js
@@ -1,4 +1,4 @@
-import { createMemoryHistory } from 'history'
+import { createMemoryHistory } from 'rudy-history'
 
 import historyCreateAction from '../src/action-creators/historyCreateAction'
 import middlewareCreate from '../src/action-creators/middlewareCreateAction'

--- a/__tests__/connectRoutes.js
+++ b/__tests__/connectRoutes.js
@@ -1,5 +1,5 @@
 import { createStore, applyMiddleware, compose } from 'redux'
-import { createMemoryHistory } from 'history'
+import { createMemoryHistory } from 'rudy-history'
 import querySerializer from 'query-string'
 
 import setup, { setupAll } from '../__test-helpers__/setup'

--- a/__tests__/connectRoutes.js
+++ b/__tests__/connectRoutes.js
@@ -1,4 +1,3 @@
-import { createStore, applyMiddleware, compose } from 'redux'
 import { createMemoryHistory } from 'rudy-history'
 import querySerializer from 'query-string'
 

--- a/__tests__/createLocationReducer.js
+++ b/__tests__/createLocationReducer.js
@@ -1,4 +1,4 @@
-import { createMemoryHistory } from 'history'
+import { createMemoryHistory } from 'rudy-history'
 import createLocationReducer, {
   getInitialState
 } from '../src/reducer/createLocationReducer'

--- a/__tests__/pure-utils.js
+++ b/__tests__/pure-utils.js
@@ -1,4 +1,4 @@
-import { createMemoryHistory, createBrowserHistory } from 'history'
+import { createMemoryHistory, createBrowserHistory } from 'rudy-history'
 
 import setup, { setupAll } from '../__test-helpers__/setup'
 

--- a/__tests__/pure-utils.js
+++ b/__tests__/pure-utils.js
@@ -1,6 +1,6 @@
 import { createMemoryHistory, createBrowserHistory } from 'rudy-history'
 
-import setup, { setupAll } from '../__test-helpers__/setup'
+import { setupAll } from '../__test-helpers__/setup'
 
 import isLocationAction from '../src/pure-utils/isLocationAction'
 import isServer from '../src/pure-utils/isServer'
@@ -174,6 +174,16 @@ describe('pathToAction(path, routesMap)', () => {
 
     const action = pathToAction(path, routesMap) /*? */
     expect(action.type).toEqual(NOT_FOUND)
+  })
+
+  it('strips basename if first segment in path', () => {
+    const path = '/base/foo/bar'
+    const routesMap = {
+      FOO: { path: '/foo/bar' }
+    }
+
+    const action = pathToAction(path, routesMap, undefined, '/base') /*? */
+    expect(action.type).toEqual('FOO')
   })
 })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-first-router",
-  "version": "0.0.2-rudy",
+  "version": "0.0.3-rudy",
   "description": "think of your app in states not routes (and, yes, while keeping the address bar in sync)",
   "main": "dist/index.js",
   "scripts": {
@@ -66,7 +66,6 @@
     "webpack": "2.4.1"
   },
   "peerDependencies": {
-    "rudy-history": "*",
     "redux": "*"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "eslint-plugin-react": "^6.10.3",
     "flow-bin": "^0.54.1",
     "flow-copy-source": "^1.1.0",
-    "history": "^4.5.1",
     "husky": "^0.13.2",
     "jest": "^21.0.1",
     "lint-staged": "^3.4.0",
@@ -67,7 +66,7 @@
     "webpack": "2.4.1"
   },
   "peerDependencies": {
-    "history": "*",
+    "rudy-history": "*",
     "redux": "*"
   },
   "jest": {

--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -120,7 +120,8 @@ export default (routesMap: RoutesMap = {}, options: Options = {}) => {
     extra
   }: Options = options
 
-  // The options must be initialized ASAP to prevent empty options after the initial events emitted
+  // The options must be initialized ASAP to prevent empty options being
+  // received in `getOptions` after the initial events emitted
   _options = options
 
   setDisplayConfirmLeave(displayConfirmLeave)
@@ -656,4 +657,4 @@ export const updateScroll = () => _updateScroll && _updateScroll()
 export const selectLocationState = (state: Object) =>
   _selectLocationState(state)
 
-export const getOptions = (): Options => _options
+export const getOptions = (): Options => _options || {}

--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -120,6 +120,9 @@ export default (routesMap: RoutesMap = {}, options: Options = {}) => {
     extra
   }: Options = options
 
+  // The options must be initialized ASAP to prevent empty options after the initial events emitted
+  _options = options
+
   setDisplayConfirmLeave(displayConfirmLeave)
 
   if (options.basename) {
@@ -558,7 +561,7 @@ export default (routesMap: RoutesMap = {}, options: Options = {}) => {
   _history = history
   _scrollBehavior = scrollBehavior
   _selectLocationState = selectLocationState
-  _options = options
+
   let _initialDispatch
   let _confirm
 

--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -1,7 +1,9 @@
 // @flow
 import { compilePath } from 'rudy-match-path'
-import { NOT_FOUND } from '../index'
+import { stripBasename } from 'rudy-history'
+import { NOT_FOUND, getOptions } from '../index'
 import objectValues from './objectValues'
+
 import type { RoutesMap, ReceivedAction, QuerySerializer } from '../flow-types'
 
 export default (
@@ -15,7 +17,11 @@ export default (
   const routes = objectValues(routesMap)
   const routeTypes = Object.keys(routesMap)
 
-  pathname = parts[0]
+  const options = getOptions()
+
+  pathname = options
+    ? options.basename ? stripBasename(parts[0], options.basename) : parts[0]
+    : parts[0]
 
   let i = 0
   let match

--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -1,6 +1,6 @@
 // @flow
 import { compilePath } from 'rudy-match-path'
-import { stripBasename } from 'rudy-history'
+import { stripBasename } from 'rudy-history/PathUtils'
 import { NOT_FOUND, getOptions } from '../index'
 import objectValues from './objectValues'
 
@@ -9,7 +9,8 @@ import type { RoutesMap, ReceivedAction, QuerySerializer } from '../flow-types'
 export default (
   pathname: string,
   routesMap: RoutesMap,
-  serializer?: QuerySerializer
+  serializer?: QuerySerializer,
+  basename?: string = getOptions().basename
 ): ReceivedAction => {
   const parts = pathname.split('?')
   const search = parts[1]
@@ -17,11 +18,7 @@ export default (
   const routes = objectValues(routesMap)
   const routeTypes = Object.keys(routesMap)
 
-  const options = getOptions()
-
-  pathname = options
-    ? options.basename ? stripBasename(parts[0], options.basename) : parts[0]
-    : parts[0]
+  pathname = basename ? stripBasename(parts[0], basename) : parts[0]
 
   let i = 0
   let match


### PR DESCRIPTION
Added `basename` stripping to get the correct matching between map and URL. Also I push above the `option` initialization (from side effects part) to prevent it been uninitialized between the creation of `connectRoute` and the first initial action dispatching. Otherwise `getOption` returns `undefined` when the first route do its job. The original `history` removed from deps completely.

_Notice here:_
test snapsot **'nestHistory formats simplified history object for action + state'** was changed by me because all enrties have real value in key property after updated to our rudy-history. Please make sure I was right when I change this snapshot, may be, I don't understand smth...