### PR TITLE
feat(pathToAction function and RouteObject type): pathToAction respec…

### DIFF
--- a/__tests__/pure-utils.js
+++ b/__tests__/pure-utils.js
@@ -154,6 +154,21 @@ describe('pathToAction(path, routesMap)', () => {
     expect(action.payload.param).toEqual(69)
   })
 
+  describe('when the route has flag "noParseParams', () => {
+    it('should not parse the route', () => {
+      const path = '/info/0x12345'
+      const routesMap = {
+        INFO_NO_PARSE: {
+          path: '/info/:param',
+          noParseParams: true
+        }
+      }
+
+      const action = pathToAction(path, routesMap)
+      expect(action.payload.param).toEqual('0x12345')
+    })
+  })
+
   it('does not parse a blank string "" as NaN', () => {
     const path = '/info'
     const routesMap = {

--- a/src/flow-types.js
+++ b/src/flow-types.js
@@ -11,7 +11,8 @@ export type RouteObject = {
   toPath?: (param: string, key?: string) => string,
   fromPath?: (path: string, key?: string) => string,
   thunk?: (dispatch: Dispatch, getState: GetState) => any | Promise<any>,
-  navKey?: string
+  navKey?: string,
+  noParseParams?: boolean
 }
 
 export type Route = RouteString | RouteObject

--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -39,23 +39,26 @@ export default (
       typeof routes[i].fromPath === 'function' &&
       routes[i].fromPath
     const type = routeTypes[i]
+    const noParseParams = !!routes[i].noParseParams
 
     const payload = keys.reduce((payload, key, index) => {
       let value = match && match[index + 1] // item at index 0 is the overall match, whereas those after correspond to the key's index
 
-      value = typeof value === 'string' &&
-        !value.match(/^\s*$/) &&
-        !isNaN(value) // check that value is not a blank string, and is numeric
-        ? parseFloat(value) // make sure pure numbers aren't passed to reducers as strings
-        : value
+      if (!noParseParams) {
+        value = typeof value === 'string' &&
+          !value.match(/^\s*$/) &&
+          !isNaN(value) // check that value is not a blank string, and is numeric
+          ? parseFloat(value) // make sure pure numbers aren't passed to reducers as strings
+          : value
 
-      value = capitalizedWords && typeof value === 'string'
-        ? value.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase()) // 'my-category' -> 'My Category'
-        : value
+        value = capitalizedWords && typeof value === 'string'
+          ? value.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase()) // 'my-category' -> 'My Category'
+          : value
 
-      value = fromPath && typeof value === 'string'
-        ? fromPath(value, key.name)
-        : value
+        value = fromPath && typeof value === 'string'
+          ? fromPath(value, key.name)
+          : value
+      }
 
       payload[key.name] = value
 

--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -32,14 +32,17 @@ export default (
   if (match) {
     i--
 
-    const capitalizedWords =
-      typeof routes[i] === 'object' && routes[i].capitalizedWords
-    const fromPath =
-      routes[i] &&
-      typeof routes[i].fromPath === 'function' &&
-      routes[i].fromPath
     const type = routeTypes[i]
-    const noParseParams = !!routes[i].noParseParams
+    let capitalizedWords = false
+    let fromPath = false
+    let noParseParams = false
+
+    // determine if we have a RouteString or RouteObject
+    if (typeof routes[i] === 'object') {
+      capitalizedWords = routes[i].capitalizedWords
+      fromPath = typeof routes[i].fromPath === 'function' && routes[i].fromPath
+      noParseParams = !!routes[i].noParseParams
+    }
 
     const payload = keys.reduce((payload, key, index) => {
       let value = match && match[index + 1] // item at index 0 is the overall match, whereas those after correspond to the key's index


### PR DESCRIPTION
…ts the noParseParams property f

A route param that passes the isNaN check will have parseFloat applied to it; this should not be the
behaviour for all numbers, for example hexadecimals.

BREAKING CHANGE: n/a

n/a