### PR TITLE
fix(flow types export): fixes export of types by adding flow annotation to index file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+// @flow
 export {
   default as connectRoutes,
   push,


### PR DESCRIPTION
Fixes #115 by adding the flow annotation to the index file.

I am not sure whether this should be a major version release. Given all the types at the moment are exported as 'any', this change could break consumers using flow.