### PR TITLE
fix($browser): Add support for parsing multi-segment path action params

### DIFF
--- a/__tests__/pure-utils.js
+++ b/__tests__/pure-utils.js
@@ -198,6 +198,20 @@ describe('actionToPath(action, routesMap)', () => {
     expect(path).toEqual('/info/foo')
   })
 
+  it('parse action payload with array param into multiple path segments: /info/foo/bar/baz', () => {
+    const action = {
+      type: 'INFO_PARAM',
+      payload: { param: ['foo', 'bar', 'baz'] }
+    }
+    const routesMap = {
+      INFO: '/info',
+      INFO_PARAM: '/info/:param*'
+    }
+
+    const path = actionToPath(action, routesMap) /*? */
+    expect(path).toEqual('/info/foo/bar/baz')
+  })
+
   it('parse action into path with numerical payload key value: /info/69', () => {
     const action = { type: 'INFO_PARAM', payload: { param: 69 } }
     const routesMap = {

--- a/src/pure-utils/actionToPath.js
+++ b/src/pure-utils/actionToPath.js
@@ -16,9 +16,10 @@ export default (
 ): string => {
   const route = routesMap[action.type]
   const routePath = typeof route === 'object' ? route.path : route
-  const params = typeof route === 'object'
-    ? _payloadToParams(route, action.payload)
-    : action.payload
+  const params =
+    typeof route === 'object'
+      ? _payloadToParams(route, action.payload)
+      : action.payload
 
   const path = pathToRegexp.compile(routePath)(params || {}) || '/'
 
@@ -45,6 +46,12 @@ const _payloadToParams = (route: RouteObject, params: Payload = {}): Params =>
         sluggifedParams[key] = route.toPath(params[key], key)
       }
       else if (typeof params[key] === 'string') {
+        sluggifedParams[key] = params[key]
+      }
+      else if (
+        typeof params[key] === 'object' &&
+        Array.isArray(params[key])
+      ) {
         sluggifedParams[key] = params[key]
       }
     }


### PR DESCRIPTION
Add logic to the payload parsing in actionToPath to keep array parameters
enabling pathToRegexp to compile +/* multi-segments in path definitions.

Fixes (#139).

