### PR TITLE
query should be an empty object if none

### DIFF
--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -11,7 +11,7 @@ export default (
 ): ReceivedAction => {
   const parts = pathname.split('?')
   const search = parts[1]
-  const query = search && serializer && serializer.parse(search)
+  const query = search && serializer && serializer.parse(search) || {}
   const routes = objectValues(routesMap)
   const routeTypes = Object.keys(routesMap)
 


### PR DESCRIPTION
So that I don't need to do `location.query || {}` to access my query.

This is consistent with react-router