### PR TITLE
[Fix][#175] Use custom location state selector in not found action creator

### DIFF
--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -270,7 +270,7 @@ export default (routesMap: RoutesMap = {}, options: Options = {}) => {
       // user decided to dispatch `NOT_FOUND`, so we fill in the missing location info
       action = middlewareCreateNotFoundAction(
         action,
-        store.getState().location,
+        selectLocationState(store.getState()),
         prevLocation,
         history,
         notFoundPath


### PR DESCRIPTION

This PR is intended to fix the issue with not found actions ( #175 ) and custom location path in state. It happens because `middlewareCreateNotFoundAction` tries to get the location from the default path in state, rather than using the custom selector. 

This appears to already have been fixed in the `master` branch: https://github.com/faceyspacey/redux-first-router/blob/master/src/connectRoutes.js#L225

I cannot find an equivalent issue in `rudy-next`, but it might be worth a double-check.

Thanks to @nicholasgwk for identifying this fix. 🎉 