### PR TITLE
Quick fix for tests using node env.

### DIFF
--- a/src/pure-utils/changePageTitle.js
+++ b/src/pure-utils/changePageTitle.js
@@ -10,7 +10,7 @@ export default (doc: Document, title: ?string): ?string => {
 }
 
 export const getDocument = (): Document => {
-  const isSSRTest = process.env.NODE_ENV === 'test' && window.isSSR
+  const isSSRTest = process.env.NODE_ENV === 'test' && typeof window !== 'undefined' && window.isSSR
 
   return typeof document !== 'undefined' && !isSSRTest ? document : {}
 }


### PR DESCRIPTION
This is a needed fix for app doing integration tests without jsdom (SSR).

I know you have this all changed up in the rudy-next branch, but that's not on NPM as far as I can tell.

Without this, I get the following error:

    ReferenceError: window is not defined

      at getDocument (node_modules/redux-first-router/dist/pure-utils/changePageTitle.js:16:54)
      at Object.<anonymous>.exports.default (node_modules/redux-first-router/dist/connectRoutes.js:220:57)
      at configureStore (src/apollo-gateway-integration.test.js:59:56)
      at Object.it (src/apollo-gateway-integration.test.js:270:21)
          at new Promise (<anonymous>)
          at <anonymous>
