### PR TITLE
feat($browser): Update path-to-regexp to support toPathOptions...

### DIFF
--- a/__tests__/pure-utils.js
+++ b/__tests__/pure-utils.js
@@ -122,7 +122,7 @@ describe('pathToAction(path, routesMap)', () => {
   it('parse path (/info/foo-bar) into action using route object containing capitalizedWords: true: payload: { param: "Foo Bar" }', () => {
     const path = '/info/foo-bar'
     const routesMap = {
-      INFO_PARAM: { path: '/info/:param/', capitalizedWords: true }
+      INFO_PARAM: { path: '/info/:param', capitalizedWords: true }
     }
 
     const action = pathToAction(path, routesMap) /*? */
@@ -130,10 +130,10 @@ describe('pathToAction(path, routesMap)', () => {
   })
 
   it('parse path into action using route object containing fromPath() function', () => {
-    const path = '/info/foo-bar'
+    const path = '/info/foo-bar/'
     const routesMap = {
       INFO_PARAM: {
-        path: '/info/:param/',
+        path: '/info/:param',
         fromPath: (segment, key) =>
           `${segment} ${key}`.replace('-', ' ').toUpperCase()
       }
@@ -144,9 +144,9 @@ describe('pathToAction(path, routesMap)', () => {
   })
 
   it('parse path containing number param into action with payload value set as integer instead of string', () => {
-    const path = '/info/69'
+    const path = '/info/69/'
     const routesMap = {
-      INFO_PARAM: { path: '/info/:param/' }
+      INFO_PARAM: { path: '/info/:param' }
     }
 
     const action = pathToAction(path, routesMap) /*? */
@@ -259,6 +259,20 @@ describe('actionToPath(action, routesMap)', () => {
     const routesMap = { INFO_PARAM: '/:param?' }
     const path = actionToPath(action, routesMap) /*? */
     expect(path).toEqual('/')
+  })
+
+  it('forwards toPathOptions to path-to-regexp toPath', () => {
+    const action = { type: 'INFO', payload: { param: '1,2' } }
+    const routesMap = {
+      INFO: {
+        path: '/info/:param',
+        toPathOptions: {
+          encode: param => param
+        }
+      }
+    }
+    const path = actionToPath(action, routesMap) /*? */
+    expect(path).toEqual('/info/1,2')
   })
 })
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/faceyspacey/redux-first-router#readme",
   "dependencies": {
-    "path-to-regexp": "^1.7.0"
+    "path-to-regexp": "^2.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/src/pure-utils/actionToPath.js
+++ b/src/pure-utils/actionToPath.js
@@ -16,11 +16,15 @@ export default (
 ): string => {
   const route = routesMap[action.type]
   const routePath = typeof route === 'object' ? route.path : route
+  const toPathOptions = typeof route === 'object'
+    ? route.toPathOptions
+    : undefined
   const params = typeof route === 'object'
     ? _payloadToParams(route, action.payload)
     : action.payload
 
-  const path = pathToRegexp.compile(routePath)(params || {}) || '/'
+  const path =
+    pathToRegexp.compile(routePath)(params || {}, toPathOptions) || '/'
 
   const query =
     action.query ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -3045,10 +3045,6 @@ is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -4343,11 +4339,9 @@ path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
-path-to-regexp@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
-  dependencies:
-    isarray "0.0.1"
+path-to-regexp@^2.1.0:
+  version "2.1.0"
+  resolved "http://npm.services.kambi.com:4873/path-to-regexp/-/path-to-regexp-2.1.0.tgz#7e30f9f5b134bd6a28ffc2e3ef1e47075ac5259b"
 
 path-type@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Update path-to-regexp to support toPathOptions from routeMap

We had to be able to overload the encode-method provided by options to toPath

BREAKING CHANGE: Latest version of path-to-regexp will honor required suffixing forwardslash if
provided in route