### PR TITLE
Test if window exists before accessing property

### DIFF
--- a/src/pure-utils/changePageTitle.js
+++ b/src/pure-utils/changePageTitle.js
@@ -10,7 +10,7 @@ export default (doc: Document, title: ?string): ?string => {
 }
 
 export const getDocument = (): Document => {
-  const isSSRTest = process.env.NODE_ENV === 'test' && window.isSSR
+  const isSSRTest = process.env.NODE_ENV === 'test' && typeof window !== 'undefined' && window.isSSR
 
   return typeof document !== 'undefined' && !isSSRTest ? document : {}
 }


### PR DESCRIPTION
When I build my app with `NODE_ENV` equal to `test` (for E2E, don't ask why it's not `production`) I get an error `window` is not defined on node (what seems to make sense). This is the only place I found where `window` is accessed without preceding `typeof` condition.