### PR TITLE
fix hexa param parsing on path to action

### DIFF
--- a/__tests__/pure-utils.js
+++ b/__tests__/pure-utils.js
@@ -154,6 +154,17 @@ describe('pathToAction(path, routesMap)', () => {
     expect(action.payload.param).toEqual(69)
   })
 
+  it('parse path containing hexadecimal param into action with payload value set as string', () => {
+    const path = '/info/0x12'
+    const routesMap = {
+      INFO_PARAM: { path: '/info/:param/' }
+    }
+
+    const action = pathToAction(path, routesMap) /*? */
+    expect(typeof action.payload.param).toEqual('string')
+    expect(action.payload.param).toEqual('0x12')
+  })
+
   it('does not parse a blank string "" as NaN', () => {
     const path = '/info'
     const routesMap = {

--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -43,9 +43,7 @@ export default (
     const payload = keys.reduce((payload, key, index) => {
       let value = match && match[index + 1] // item at index 0 is the overall match, whereas those after correspond to the key's index
 
-      value = typeof value === 'string' &&
-        !value.match(/^\s*$/) &&
-        !isNaN(value) // check that value is not a blank string, and is numeric
+      value = typeof value === 'string' && value.match(/^\d+$/)
         ? parseFloat(value) // make sure pure numbers aren't passed to reducers as strings
         : value
 


### PR DESCRIPTION
The current test to determine a number can modify param.
Example: 
```js
!isNaN('0x12')     // true
parseFloat('0x12') // 0
```