### PR TITLE
feat($routeMap): Accept meta information in routesMap

### DIFF
--- a/src/flow-types.js
+++ b/src/flow-types.js
@@ -22,7 +22,8 @@ export type RouteObject = {
     bag: Bag
   ) => any | Promise<any>,
   navKey?: string,
-  confirmLeave?: ConfirmLeave
+  confirmLeave?: ConfirmLeave,
+  meta?: Object
 }
 
 export type Route = RouteString | RouteObject

--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -49,6 +49,8 @@ export default (
       typeof routes[i].fromPath === 'function' &&
       routes[i].fromPath
 
+    const userMeta = typeof routes[i] === 'object' && routes[i].meta
+
     const type = routeTypes[i]
 
     const payload = (keys || []).reduce((payload, key, index) => {
@@ -70,7 +72,11 @@ export default (
       return payload
     }, {})
 
-    return { type, payload, meta: query ? { query } : {} }
+    const meta = {
+      ...(userMeta ? { meta: userMeta } : {}),
+      ...(query ? { query } : {})
+    }
+    return { type, payload, meta }
   }
 
   // This will basically will only end up being called if the developer is manually calling history.push().


### PR DESCRIPTION
Allows user to configure routes map to dispatch additional meta information in the aciton when a
route is matched.

Could this get squeezed in? It would be very helpful in tracking intermediate routing states (as brought up in Gitter chat)