### PR TITLE
fix(pure-utils): Add option not to parse path params into numbers

### DIFF
--- a/__tests__/pure-utils.js
+++ b/__tests__/pure-utils.js
@@ -143,7 +143,7 @@ describe('pathToAction(path, routesMap)', () => {
     expect(action.payload.param).toEqual('FOO BAR PARAM')
   })
 
-  it('parse path containing number param into action with payload value set as integer instead of string', () => {
+  it('by default parse path containing number param into action with payload value set as integer instead of string', () => {
     const path = '/info/69'
     const routesMap = {
       INFO_PARAM: { path: '/info/:param/' }
@@ -152,6 +152,17 @@ describe('pathToAction(path, routesMap)', () => {
     const action = pathToAction(path, routesMap) /*? */
     expect(typeof action.payload.param).toEqual('number')
     expect(action.payload.param).toEqual(69)
+  })
+
+  it('with parseNumbers as false do not parse path containing number param into action with payload value set as integer instead of string', () => {
+    const path = '/info/69'
+    const routesMap = {
+      INFO_PARAM: { path: '/info/:param/', parseNumbers: false }
+    }
+
+    const action = pathToAction(path, routesMap) /*? */
+    expect(typeof action.payload.param).toEqual('string')
+    expect(action.payload.param).toEqual('69')
   })
 
   it('does not parse a blank string "" as NaN', () => {

--- a/src/flow-types.js
+++ b/src/flow-types.js
@@ -8,6 +8,7 @@ export type RouteString = string
 export type RouteObject = {
   path: string,
   capitalizedWords?: boolean,
+  parseNumbers?: boolean,
   toPath?: (param: string, key?: string) => string,
   fromPath?: (path: string, key?: string) => string,
   thunk?: (dispatch: Dispatch, getState: GetState) => any | Promise<any>,

--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -34,6 +34,8 @@ export default (
 
     const capitalizedWords =
       typeof routes[i] === 'object' && routes[i].capitalizedWords
+    const parseNumbers = !(typeof routes[i] === 'object' &&
+      routes[i].parseNumbers === false)
     const fromPath =
       routes[i] &&
       typeof routes[i].fromPath === 'function' &&
@@ -43,7 +45,8 @@ export default (
     const payload = keys.reduce((payload, key, index) => {
       let value = match && match[index + 1] // item at index 0 is the overall match, whereas those after correspond to the key's index
 
-      value = typeof value === 'string' &&
+      value = parseNumbers &&
+        typeof value === 'string' &&
         !value.match(/^\s*$/) &&
         !isNaN(value) // check that value is not a blank string, and is numeric
         ? parseFloat(value) // make sure pure numbers aren't passed to reducers as strings

--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -29,47 +29,45 @@ export default (
     i++
   }
 
-  if (match) {
-    i--
-
-    const capitalizedWords =
-      typeof routes[i] === 'object' && routes[i].capitalizedWords
-    const parseNumbers = !(typeof routes[i] === 'object' &&
-      routes[i].parseNumbers === false)
-    const fromPath =
-      routes[i] &&
-      typeof routes[i].fromPath === 'function' &&
-      routes[i].fromPath
-    const type = routeTypes[i]
-
-    const payload = keys.reduce((payload, key, index) => {
-      let value = match && match[index + 1] // item at index 0 is the overall match, whereas those after correspond to the key's index
-
-      value = parseNumbers &&
-        typeof value === 'string' &&
-        !value.match(/^\s*$/) &&
-        !isNaN(value) // check that value is not a blank string, and is numeric
-        ? parseFloat(value) // make sure pure numbers aren't passed to reducers as strings
-        : value
-
-      value = capitalizedWords && typeof value === 'string'
-        ? value.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase()) // 'my-category' -> 'My Category'
-        : value
-
-      value = fromPath && typeof value === 'string'
-        ? fromPath(value, key.name)
-        : value
-
-      payload[key.name] = value
-
-      return payload
-    }, {})
-
-    return { type, payload, meta: query ? { query } : {} }
+  if (!match) {
+    // This will basically will only end up being called if the developer is manually calling history.push().
+    // Or, if visitors visit an invalid URL, the developer can use the NOT_FOUND type to show a not-found page to
+    const meta = { notFoundPath: pathname, ...(query ? { query } : {}) }
+    return { type: NOT_FOUND, payload: {}, meta }
   }
 
-  // This will basically will only end up being called if the developer is manually calling history.push().
-  // Or, if visitors visit an invalid URL, the developer can use the NOT_FOUND type to show a not-found page to
-  const meta = { notFoundPath: pathname, ...(query ? { query } : {}) }
-  return { type: NOT_FOUND, payload: {}, meta }
+  i--
+
+  const capitalizedWords =
+    typeof routes[i] === 'object' && routes[i].capitalizedWords
+  const parseNumbers = !(typeof routes[i] === 'object' &&
+    routes[i].parseNumbers === false)
+  const fromPath =
+    routes[i] && typeof routes[i].fromPath === 'function' && routes[i].fromPath
+  const type = routeTypes[i]
+
+  const payload = keys.reduce((payload, key, index) => {
+    let value = match && match[index + 1] // item at index 0 is the overall match, whereas those after correspond to the key's index
+
+    value = parseNumbers &&
+      typeof value === 'string' &&
+      !value.match(/^\s*$/) &&
+      !isNaN(value) // check that value is not a blank string, and is numeric
+      ? parseFloat(value) // make sure pure numbers aren't passed to reducers as strings
+      : value
+
+    value = capitalizedWords && typeof value === 'string'
+      ? value.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase()) // 'my-category' -> 'My Category'
+      : value
+
+    value = fromPath && typeof value === 'string'
+      ? fromPath(value, key.name)
+      : value
+
+    payload[key.name] = value
+
+    return payload
+  }, {})
+
+  return { type, payload, meta: query ? { query } : {} }
 }


### PR DESCRIPTION
This allows developer to have the router not do automatic string to number parsing on some routes.
Numeric strings with too big values will not parse correctly to integers and this fix allows
bypassing the default behavior of parsing strings into integers.

BREAKING CHANGE: None

https://github.com/faceyspacey/redux-first-router/issues/242