### PR TITLE
New Options param for rudy-match-path

### DIFF
--- a/src/pure-utils/actionToPath.js
+++ b/src/pure-utils/actionToPath.js
@@ -16,8 +16,9 @@ export default (
 ): string => {
   const route = routesMap[action.type]
   const routePath = typeof route === 'object' ? route.path : route
+  const options = typeof route === 'object' ? route.options : {}
   const params = _payloadToParams(route, action.payload)
-  const path = compileParamsToPath(routePath, params) || '/'
+  const path = compileParamsToPath(routePath, params, options) || '/'
 
   const query =
     action.query ||


### PR DESCRIPTION
New options parameter passed to rudy-match-path function compileParamsToPath ( options can be configured as a property in routesMap )