### PR TITLE
Ignore vulnerabilities detected by skyk that exist in development only

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,23 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.12.0
-ignore: {}
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'npm:chownr:20180731':
+    - cacache > chownr:
+        reason: 'Introduced via semantic-release, not relevant in production'
+    - npm-profile > make-fetch-happen > cacache > chownr:
+        reason: 'Introduced via semantic-release, not relevant in production'
+    - libcipm > pacote > cacache > chownr:
+        reason: 'Introduced via semantic-release, not relevant for production'
+    - libcipm > pacote > tar > chownr:
+        reason: 'Introduced via semantic-release, not relevant for production'
+    - npm-registry-fetch > make-fetch-happen > cacache > chownr:
+        reason: 'Introduced via semantic-release, not relevant for production'
+    - libcipm > pacote > make-fetch-happen > cacache > chownr:
+        reason: 'Introduced via semantic-release, not relevant for production'
+    - libnpmhook > npm-registry-fetch > make-fetch-happen > cacache > chownr:
+        reason: 'Introduced via semantic-release, not relevant for production'
+  'npm:mem:20180117':
+    - libnpx > yargs > os-locale > mem:
+        reason: 'Introduced via semantic-release, not relevant for production'
 patch: {}


### PR DESCRIPTION
They are all introduced via semantic-release/npm (latest versions), and therefore not an issue in production. I'd say they are both very low risk in development.
- https://github.com/isaacs/chownr/issues/14
- https://github.com/sindresorhus/mem/issues/14