### PR TITLE
Add coerceNumbers flag to routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Here's the primary (and very minimal *easy to remember*) set of configuration op
 const routesMap = {
   HOME: '/home', // plain path strings or route objects can be used
   CATEGORY: { path: '/category/:cat', capitalizedWords: true },
+  PAGE: { path: '/page/:num', coerceNumbers: false },
   USER: { 
     path: '/user/:cat/:name',
     fromPath: path => capitalizeWords(path.replace(/-/g, ' ')),

--- a/docs/connectRoutes.md
+++ b/docs/connectRoutes.md
@@ -106,6 +106,7 @@ When using* **Redux First Router**, *do not dispatch payloads that are primitive
 Features:
 * **route as a string** is simply a path to match to an action type without any transformations
 * **capitalizedWords** when true will break apart hyphenated paths into words, each with the first character capitalizedWords
+* **coerceNumbers** when false will prevent numberic paths from being parsed into Numbers (default true)
 * **toPath** will one-by-one take the keys and values of your payload object and transform them into path segments. So for a payload
 with multiple key/value pairs, it will call `toPath` multiple times, passing in the individual value as the first argument
 and the individual key name as the second argument.

--- a/docs/reducer.md
+++ b/docs/reducer.md
@@ -87,6 +87,7 @@ type RoutesMap = {
 type RouteObject = {
   path: string,
   capitalizedWords?: boolean,
+  coerceNumbers?: boolean,
   toPath?: (param: string, key?: string) => string,
   fromPath?: (path: string, key?: string) => string,
   thunk?: (dispatch: Function, getState: Function) => Promise<any>

--- a/src/flow-types.js
+++ b/src/flow-types.js
@@ -8,6 +8,7 @@ export type RouteString = string
 export type RouteObject = {
   path: string,
   capitalizedWords?: boolean,
+  coerceNumbers?: boolean,
   toPath?: (param: string, key?: string) => string,
   fromPath?: (path: string, key?: string) => string,
   thunk?: (dispatch: Dispatch, getState: GetState) => any | Promise<any>,

--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -34,6 +34,9 @@ export default (
 
     const capitalizedWords =
       typeof routes[i] === 'object' && routes[i].capitalizedWords
+
+    const coerceNumbers = !(typeof routes[i] === 'object' &&
+      routes[i].coerceNumbers === false)
     const fromPath =
       routes[i] &&
       typeof routes[i].fromPath === 'function' &&
@@ -44,6 +47,7 @@ export default (
       let value = match && match[index + 1] // item at index 0 is the overall match, whereas those after correspond to the key's index
 
       value = typeof value === 'string' &&
+        coerceNumbers &&
         !value.match(/^\s*$/) &&
         !isNaN(value) // check that value is not a blank string, and is numeric
         ? parseFloat(value) // make sure pure numbers aren't passed to reducers as strings


### PR DESCRIPTION
Add a coerceNumbers flag to *allow authors* to prevent routes like `000123` from being converted to`123`.

The default behavior is still coercion, since this would otherwise be a breaking change.