### PR TITLE
Integer coercion fix for Rudy

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Here's the primary (and very minimal *easy to remember*) set of configuration op
 const routesMap = {
   HOME: '/home', // plain path strings or route objects can be used
   CATEGORY: { path: '/category/:cat', capitalizedWords: true },
+  PAGE: { path: '/page/:num', coerceNumbers: true },
   USER: { 
     path: '/user/:cat/:name',
     fromPath: path => capitalizeWords(path.replace(/-/g, ' ')),

--- a/docs/connectRoutes.md
+++ b/docs/connectRoutes.md
@@ -73,6 +73,7 @@ Path is **optional**. If you do not provide it, the action will not be synced wi
 but you can still use the `thunk` option to declaratively specify which thunks will occur
 in response to which actions. See the [example](../examples/pathlessRoutes.js) for more details.
 * **capitalizedWords** when true will break apart hyphenated paths into words, each with the first character capitalized
+* **coerceNumbers** when true will parse numeric paths into Numbers (default false)
 * **toPath** will one-by-one take the keys and values of your payload object and transform them into path segments. So for a payload
 with multiple key/value pairs, it will call `toPath` multiple times, passing in the individual value as the first argument
 and the individual key name as the second argument.

--- a/docs/reducer.md
+++ b/docs/reducer.md
@@ -87,6 +87,7 @@ type RoutesMap = {
 type RouteObject = {
   path: string,
   capitalizedWords?: boolean,
+  coerceNumbers?: boolean,
   toPath?: (param: string, key?: string) => string,
   fromPath?: (path: string, key?: string) => string,
   thunk?: (dispatch: Function, getState: Function) => Promise<any>

--- a/src/flow-types.js
+++ b/src/flow-types.js
@@ -14,6 +14,7 @@ export type Bag = {
 export type RouteObject = {
   path: string,
   capitalizedWords?: boolean,
+  coerceNumbers?: boolean,
   toPath?: (param: string, key?: string) => string,
   fromPath?: (path: string, key?: string) => string,
   thunk?: (

--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -44,6 +44,10 @@ export default (
     const capitalizedWords =
       typeof routes[i] === 'object' && routes[i].capitalizedWords
 
+
+    const coerceNumbers =
+      typeof routes[i] === 'object' && routes[i].coerceNumbers
+
     const fromPath =
       routes[i] &&
       typeof routes[i].fromPath === 'function' &&
@@ -60,7 +64,7 @@ export default (
         if (fromPath) {
           val = fromPath && fromPath(val, key.name)
         }
-        else if (isNumber(val)) {
+        else if (coerceNumbers && isNumber(val)) {
           val = parseFloat(val)
         }
         else if (capitalizedWords) {


### PR DESCRIPTION
Context: #292 

This adds a `coerceNumbers` flag to the RouteObject that is **false by default**.

Why implement it this way? Why not just take out this behavior entirely?

1. Type coercion should not be done without explicit user opt-in (IMO). It can lead to unexpected behavior & bugs.
2. However, parsing integers in a URL still feels useful sometimes. I used to use [this package](https://www.npmjs.com/package/express-query-int) in Express, why shouldn't Rudy have something similar?
3. If users are migrating to Rudy from the old master branch, and they relied on the old behavior, keeping this as an option gives them an easier migration path. Simply enable this flag on the routes where you need it.

@ScriptedAlchemy let me know what you think!