### PR TITLE
fix node 6 support, remove usage of Object.entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
   - stable
+  - 6
 cache: yarn
+install: yarn --ignore-engines # ignore engines to test node 6, otherwise it fails on engine check
 script:
   - node_modules/.bin/travis-github-status lint flow jest node_modules/.bin/snyk codeclimate
 notifications:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   </a>
   
   <a href="https://www.npmjs.com/package/redux-first-router">
-    <img src=https://img.shields.io/node/v/redux-first-router.svg" alt="Min Node Version: 8" />
+    <img src="https://img.shields.io/node/v/redux-first-router.svg" alt="Min Node Version: 6" />
   </a>
 
   <a href="https://travis-ci.org/faceyspacey/redux-first-router">

--- a/__tests__/connectRoutes.js
+++ b/__tests__/connectRoutes.js
@@ -9,6 +9,10 @@ import { NOT_FOUND } from '../src/index'
 import redirect from '../src/action-creators/redirect'
 import pathToAction from '../src/pure-utils/pathToAction'
 
+beforeEach(() => {
+  window.SSRtest = false
+})
+
 describe('middleware', () => {
   it('dispatches location-aware action, changes address bar + document.title', () => {
     const { store, history } = setupAll()

--- a/__tests__/pure-utils.js
+++ b/__tests__/pure-utils.js
@@ -12,6 +12,10 @@ import changePageTitle from '../src/pure-utils/changePageTitle'
 
 import { NOT_FOUND } from '../src/index'
 
+beforeEach(() => {
+  window.SSRtest = false
+})
+
 it('isLocationAction(action) if has meta.location object', () => {
   let ret = isLocationAction({})
   expect(ret).toBeFalsy()

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -6,8 +6,6 @@ While RFR2 is a breaking change, its trivial to get up and running again.
 
 Inside of your `configureStore.js` [file](https://github.com/scriptedalchemy/redux-first-router-demo/blob/6c8238eee713ce0079aeae1ce328d305bddd0ee3/src/configureStore.js#L11),
 
-This package requires ***Node 8 and up***
-
 Change this:
 ```js
   const { reducer, middleware, enhancer, thunk } = connectRoutes(

--- a/docs/redux-persist.md
+++ b/docs/redux-persist.md
@@ -40,7 +40,8 @@ export default {
 
 const parseCookies = (cookies) => {
   const parsedCookies = {}
-  Object.entries(cookies).forEach(([key, value]) => {
+  Object.keys(cookies).forEach((key) => {
+    const value = cookies[key]
     const decodedKey = decodeURIComponent(key)
     const keyWithoutReduxPersistPrefix = decodedKey.replace(/reduxPersist:/, '')
     if (key !== 'reduxPersistIndex') { // TODO: This could be expanded into a real black- or whitelist

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "think of your app in states not routes (and, yes, while keeping the address bar in sync)",
   "main": "dist/index.js",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=6.0.0"
   },
   "scripts": {
     "build": "babel src -d dist",

--- a/src/pure-utils/actionToPath.js
+++ b/src/pure-utils/actionToPath.js
@@ -30,7 +30,8 @@ export default (
 }
 
 const _payloadToParams = (route: Route, params: Payload = {}): Params =>
-  Object.entries(params).reduce((sluggifedParams, [key, segment]) => {
+  Object.keys(params).reduce((sluggifedParams, key) => {
+    const segment = params[key]
     // $FlowFixMe
     sluggifedParams[key] = transformSegment(segment, route, key)
     return sluggifedParams


### PR DESCRIPTION
when upgrading to RFR 2.0, found that it doesn't support node 6 anymore, but the only offender seems to be using `Object.entries`, I think it will save everyone's time, if we just keep supporting node 6, since effort is small and this is in maintenance stage