### PR TITLE
feat(connectRoutes): add strict option for trailing delimiter

### DIFF
--- a/__tests__/pure-utils.js
+++ b/__tests__/pure-utils.js
@@ -203,6 +203,21 @@ describe('pathToAction(path, routesMap)', () => {
     const action = pathToAction(path, routesMap, undefined, '/base') /*? */
     expect(action.type).toEqual('FOO')
   })
+
+  it('returns NOT_FOUND with a strict match with/without trailing delimiter', () => {
+    const path = '/foo/'
+    const routesMap = {
+      FOO: { path: '/foo' }
+    }
+
+    let strict = true
+    let action = pathToAction(path, routesMap, undefined, undefined, strict) /*? */
+    expect(action.type).toEqual(NOT_FOUND)
+
+    strict = false
+    action = pathToAction(path, routesMap, undefined, undefined, strict) /*? */
+    expect(action.type).toEqual('FOO')
+  })
 })
 
 describe('actionToPath(action, routesMap)', () => {

--- a/docs/connectRoutes.md
+++ b/docs/connectRoutes.md
@@ -123,6 +123,7 @@ type Options = {
   querySerializer?: {parse: Function, stringify: Function},
   displayConfirmLeave?: DisplayConfirmLeave,
   basename?: string,
+  strict?: boolean, // default: false
   extra?: any,
 }
 ```
@@ -177,6 +178,8 @@ See this [blocking navigation](./blocking-navigation.md) for more details
 * **basename** - a URL path prefix that will be prepended to the URL. For example,
 using a `basename` of `'/playground'`, A route with the path `'/home'` would correspond
 to the URL path `'/playground/home'`
+
+* **strict** - an url `/foo` will not match a route `FOO: '/foo/'` or an url `/foo/` will not match a route `FOO: '/foo'` when the `strict` option is set to `true`. This is a similar option as the `strict` prop of `<NavLink>` component from `redux-first-router-link` but this option prevents search engines to detect duplicate content (which is bad for SEO) on urls `/foo` and `/foo/`, while the `strict` prop of `<NavLink>` is only meant to determine if the link is active regarding to the current location. Note: search engines may detect duplicate content if somehow a link exists on your site or elsewhere.  
 
 * **extra** - An optional value that will be passed as part of the third `bag` argument to all route callbacks,
 including `thunk`, `onBeforeChange`, etc. It works much like the

--- a/src/flow-types.js
+++ b/src/flow-types.js
@@ -99,6 +99,7 @@ export type Options = { // eslint-disable-line no-undef
       navigationAction: ?NavigationAction
     }
   },
+  strict?: boolean,
   extra?: any
 }
 

--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -10,7 +10,8 @@ export default (
   pathname: string,
   routesMap: RoutesMap,
   serializer?: QuerySerializer,
-  basename?: string | void = getOptions().basename
+  basename?: string | void = getOptions().basename,
+  strict?: boolean | void = getOptions().strict
 ): ReceivedAction => {
   const parts = pathname.split('?')
   const search = parts[1]
@@ -32,7 +33,7 @@ export default (
       continue
     }
 
-    const { re, keys: k } = compilePath(regPath)
+    const { re, keys: k } = compilePath(regPath, { strict })
     match = re.exec(pathname)
     keys = k
     i++


### PR DESCRIPTION
/foo route's path is matching /foo and /foo/ urls by default. Setting strict option to true makes
/foo match /foo url but not /foo/.

fix faceyspacey#312