### PR TITLE
Fixes exported updateScroll function if set to manual

### DIFF
--- a/src/connectRoutes.js
+++ b/src/connectRoutes.js
@@ -575,7 +575,7 @@ export default (routesMap: RoutesMap = {}, options: Options = {}) => {
 
   _updateScroll = (performedByUser: boolean = true) => {
     if (scrollBehavior) {
-      if (!scrollBehavior.manual) {
+      if (performedByUser || !scrollBehavior.manual) {
         scrollBehavior.updateScroll(prevState, nextState)
       }
     }


### PR DESCRIPTION
Hi, this is my first time submitting a contribution to this repository. I ran into this issue when using this package and tracked it down to this conditional. Here's my use case and why I'm proposing this contribution.

## Use Case
I wanted to update the scroll after async content has been loaded from a route thunk.

In my SSR app, when requesting the page from the server, it awaits all the route thunks before rendering the app and sending to the user. However, if you are routed from the front end, the app rightly renders before all thunks are complete. One of my thunks was fetching content for the page, and so the scroll would be updated before the content shifted the layout of the page, winding up in the scroll being in the wrong place.

The answer: update the scroll manually after the content is loaded.

## The Issue
There is actually no way to manually trigger the update scroll. The function that blocks updateScroll from be invoked if `manual: true` is the same function that's exported. Without this extra condition, the user can never update scroll if it is set to manual.

## Thanks
I hope I explained this well enough. Please let me know if I'm mistaken with this or if there is a preferred way to fix this, but I confirmed this behavior was the case while using the latest `2.1.0`.

And also -- thank you for your work on this repository! I've been very much enjoying using `redux-first-router` over the alternatives.