### PR TITLE
fix(component): filter routes array in src/pathToAction.js

### DIFF
--- a/src/pure-utils/pathToAction.js
+++ b/src/pure-utils/pathToAction.js
@@ -16,8 +16,8 @@ export default (
   const parts = pathname.split('?')
   const search = parts[1]
   const query = search && serializer && serializer.parse(search)
-  const routes = objectValues(routesMap)
   const routeTypes = Object.keys(routesMap)
+  const routes = objectValues(routesMap).filter(route => typeof route === 'string' || typeof route === 'object')
 
   pathname = basename ? stripBasename(parts[0], basename) : parts[0]
 


### PR DESCRIPTION
I accidentally added an _undefined_ as a `routesMap` path and suddenly my app wouldn't resolve the 404's (because the route was at the bottom of `routesMap`, otherwise it wouldn't even resolve existant paths) so I checked that there's no filter in the `routes` array in src/pathToAction.js, meaning that whenever a non-string is supplied to the `routes` array, in the while block down bellow `regPath` ternary assumes `routes[i]` is an object with a path value in it. Making the router to fail there.
Just as the last comment, thanks for your amazing work with redux-first-router, I love it!