### PR TITLE
fix: RouterObjer.path should be optional

### DIFF
--- a/docs/connectRoutes.md
+++ b/docs/connectRoutes.md
@@ -60,7 +60,7 @@ type RoutesMap = {
 }
 
 type RouteObject = {
-  path: string,
+  path?: string,
   capitalizedWords?: boolean,
   toPath?: (value: string, key?: string) => string,
   fromPath?: (pathSegment: string, key?: string) => string,

--- a/src/flow-types.js
+++ b/src/flow-types.js
@@ -12,7 +12,7 @@ export type Bag = {
 }
 
 export type RouteObject = {
-  path: string,
+  path?: string,
   capitalizedWords?: boolean,
   coerceNumbers?: boolean,
   toPath?: (param: string, key?: string) => string,


### PR DESCRIPTION
From docs https://github.com/faceyspacey/redux-first-router/tree/master/examples/thunks#pathless-routes

> A pathless route is a `routesMap` entry without a `path`