### PR TITLE
fix(confirmLeave): update current route's history blocking after "addRoutes"

### DIFF
--- a/src/pure-utils/confirmLeave.js
+++ b/src/pure-utils/confirmLeave.js
@@ -18,7 +18,7 @@ let _unblock
 let _removeConfirmBlocking
 let _displayConfirmLeave
 
-const clearBlocking = () => {
+export const clearBlocking = () => {
   _unblock && _unblock()
   _removeConfirmBlocking && _removeConfirmBlocking()
 }


### PR DESCRIPTION
Hey!

This PR introduces support of usage scenarios when initial route is needed to be location-blocking and loaded partially (without `confirmLeave` property) on init but it's updated (adding `confirmLeave`) using `addRoutes()` later. It's necessary if the following conditions are combined:

- router related code-splitting is used;
- SSR is used;
- only serializable parts of current route's config are sent from the server (such as `path` property);
- full implementation of the routes is loaded and applied with subsequent JavaScript chunks;
- current route must block the navigation (`confirmLeave()` is present on route's full config).

We use this technique at [fish.travel](https://fish.travel) right now.

Also, [`@oopscurity/redux-first-router@2.1.2`](https://www.npmjs.com/package/@oopscurity/redux-first-router/v/2.1.2) includes these changes [applied](https://github.com/artkravchenko/redux-first-router/tree/npm/master) on the original repo's `master` branch.