### PR TITLE
Make sure getInitialState return an object with search

### DIFF
--- a/src/reducer/createLocationReducer.js
+++ b/src/reducer/createLocationReducer.js
@@ -73,6 +73,7 @@ export const getInitialState = (
   routesMap: RoutesMap,
   history: History
 ): LocationState => ({
+  search: currentPathname.split('?')[1]
   pathname: currentPathname.split('?')[0],
   type,
   payload,

--- a/src/reducer/createLocationReducer.js
+++ b/src/reducer/createLocationReducer.js
@@ -73,7 +73,7 @@ export const getInitialState = (
   routesMap: RoutesMap,
   history: History
 ): LocationState => ({
-  search: currentPathname.split('?')[1]
+  search: currentPathname.split('?')[1],
   pathname: currentPathname.split('?')[0],
   type,
   payload,


### PR DESCRIPTION
For fixing #372 

Without this, if you navigate to same route with same pathname but different query parameters, query params don't update since this if block gets triggered due to initialstate.location being undefined.

```    
route &&
      !action.error &&
      (typeof route === 'string' || route.path) &&
      (action.meta.location.current.pathname === state.pathname &&
        action.meta.location.current.search === state.search &&
        action.meta.location.kind !== state.kind
      )
  ) {
    return {
      ...state,
      kind: action.meta.location.kind
    }
  }
```

this issue happens from transitioning from http://localhost:8000/?category_id=1&page=1&sort_by=ean%3AASC to http://localhost:8000/ using NavLink from redux-first-router-link

