### PR TITLE
Fix: Include search params in pathname

### DIFF
--- a/src/pure-utils/confirmLeave.js
+++ b/src/pure-utils/confirmLeave.js
@@ -56,7 +56,7 @@ export const createConfirm = (
   const confirm = (location: HistoryLocation | Location) => {
     const state = store.getState()
     const routesMap = selectLocationState(state).routesMap
-    const pathname = location.pathname
+    const pathname = [location.pathname, location.search].filter(Boolean).join('?')
     const action = pathToAction(pathname, routesMap, querySerializer)
     const response = confirmLeave(state, action)
 


### PR DESCRIPTION
Fixes https://github.com/faceyspacey/redux-first-router/issues/426

When using confirmLeave in the routesMap, the action passed in the function doesn't contain any other data that's in the search part of the location.

Since in [pathToAction.js](https://github.com/faceyspacey/redux-first-router/blob/391f344ede84ed12ee15bc55c800b2962502ec8e/src/pure-utils/pathToAction.js#L17) we clearly expect a search part in the location:
```javascript
  const parts = pathname.split('?')
  const search = parts[1]
  const query = search && serializer && serializer.parse(search)
```

This seemed like a bug, so that explains the reason for this PR 😄 